### PR TITLE
fix up plugin manager Web Browser plugin dependency 

### DIFF
--- a/MarkdownAsset.uplugin
+++ b/MarkdownAsset.uplugin
@@ -10,10 +10,11 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"CanContainContent": true,
+	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
+	"Enabled": false,
 	"Modules": [
 		{
 			"Name": "MarkdownAsset",
@@ -24,6 +25,12 @@
 			"Name": "MarkdownAssetEditor",
 			"Type": "Editor",
 			"LoadingPhase": "PostEngineInit"
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "WebBrowserWidget",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
Add the uplugin dependency so that the WebBrowserWidget ("Web Browser") plugin will automatically be enabled in the plugin manager when this plugin is enabled.

BTW: So glad to have run across this - I was considering writing the same thing :-)